### PR TITLE
Fix plots on Python 3 and optimize slightly

### DIFF
--- a/docs/plot/plot.py
+++ b/docs/plot/plot.py
@@ -151,6 +151,7 @@ def project(coordinates, proj_string, in_radians=False):
     # proj expects binary input to be in radians
     if not in_radians:
         coordinates = np.deg2rad(coordinates)
+    coordinates = coordinates.astype(np.double, copy=False)
 
     # set up cmd call. -b for binary in/out
     args = [PROJ, '-b']
@@ -158,7 +159,7 @@ def project(coordinates, proj_string, in_radians=False):
 
     proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                             env={'PROJ_LIB': os.path.abspath(PROJ_LIB)})
-    stdout, _ = proc.communicate(coordinates.tobytes())
+    stdout, _ = proc.communicate(coordinates.tobytes(order='C'))
 
     out = np.frombuffer(stdout, dtype=np.double)
     return np.reshape(out, (-1, 2))

--- a/docs/plot/plot.py
+++ b/docs/plot/plot.py
@@ -166,8 +166,8 @@ def project_xy(x, y, proj_string):
     '''
     Wrapper for project() that works with shapely.ops.transform().
     '''
-    a = project(zip(x, y), proj_string)
-    return zip(*a)
+    a = project(np.column_stack((x, y)), proj_string)
+    return a.T
 
 
 def meridian(lon, lat_min, lat_max):
@@ -269,7 +269,8 @@ def plotproj(plotdef, data, outdir):
     frame.append(parallel(plotdef['latmax'], plotdef['lonmin'], plotdef['lonmax']))
     for line in frame:
         line = project(line, plotdef['projstring'])
-        x, y = zip(*line)
+        x = line[:, 0]
+        y = line[:, 1]
         plt.plot(x, y, '-k')
 
     graticule = build_graticule(
@@ -282,7 +283,8 @@ def plotproj(plotdef, data, outdir):
     # Plot graticule
     for feature in graticule:
         feature = project(feature, plotdef['projstring'])
-        x, y = zip(*feature)
+        x = feature[:, 0]
+        y = feature[:, 1]
         plt.plot(x, y, color=COLOR_GRAT, linewidth=0.4)
 
     axes.axis('off')

--- a/docs/plot/plot.py
+++ b/docs/plot/plot.py
@@ -227,8 +227,7 @@ def plotproj(plotdef, data, outdir):
     '''
     Plot map.
     '''
-    fig = plt.figure()
-    axes = fig.add_subplot(111)
+    fig, axes = plt.subplots()
 
     bounds = (plotdef['lonmin'], plotdef['latmin'], plotdef['lonmax'], plotdef['latmax'])
     for geom in data.filter(bbox=bounds):
@@ -261,7 +260,7 @@ def plotproj(plotdef, data, outdir):
             axes.add_patch(patch)
         else:
             x, y = proj_geom.xy
-            plt.plot(x, y, color=COLOR_COAST, linewidth=0.5)
+            axes.plot(x, y, color=COLOR_COAST, linewidth=0.5)
 
     # Plot frame
     frame = []
@@ -271,7 +270,7 @@ def plotproj(plotdef, data, outdir):
         line = project(line, plotdef['projstring'])
         x = line[:, 0]
         y = line[:, 1]
-        plt.plot(x, y, '-k')
+        axes.plot(x, y, '-k')
 
     graticule = build_graticule(
         plotdef['lonmin'],
@@ -285,7 +284,7 @@ def plotproj(plotdef, data, outdir):
         feature = project(feature, plotdef['projstring'])
         x = feature[:, 0]
         y = feature[:, 1]
-        plt.plot(x, y, color=COLOR_GRAT, linewidth=0.4)
+        axes.plot(x, y, color=COLOR_GRAT, linewidth=0.4)
 
     axes.axis('off')
     font = {
@@ -294,12 +293,12 @@ def plotproj(plotdef, data, outdir):
         'style': 'italic',
         'size': 12
     }
-    plt.suptitle(plotdef['projstring'], fontdict=font)
+    fig.suptitle(plotdef['projstring'], fontdict=font)
 
-    plt.autoscale(tight=True)
+    axes.autoscale(tight=True)
     if not os.path.exists(outdir):
         os.makedirs(outdir)
-    plt.savefig(outdir + '/' + plotdef['filename'], dpi=300)
+    fig.savefig(outdir + '/' + plotdef['filename'], dpi=300)
 
     # Clean up
     fig = None

--- a/docs/plot/plot.py
+++ b/docs/plot/plot.py
@@ -243,9 +243,7 @@ def plotproj(plotdef, data, outdir):
 
         if plotdef['type'] == 'poly':
             if isinstance(temp_pol, MultiPolygon):
-                polys = []
-                for polygon in temp_pol:
-                    polys.append(resample_polygon(polygon))
+                polys = [resample_polygon(polygon) for polygon in temp_pol]
                 pol = MultiPolygon(polys)
             else:
                 pol = resample_polygon(temp_pol)
@@ -263,9 +261,10 @@ def plotproj(plotdef, data, outdir):
             axes.plot(x, y, color=COLOR_COAST, linewidth=0.5)
 
     # Plot frame
-    frame = []
-    frame.append(parallel(plotdef['latmin'], plotdef['lonmin'], plotdef['lonmax']))
-    frame.append(parallel(plotdef['latmax'], plotdef['lonmin'], plotdef['lonmax']))
+    frame = [
+        parallel(plotdef['latmin'], plotdef['lonmin'], plotdef['lonmax']),
+        parallel(plotdef['latmax'], plotdef['lonmin'], plotdef['lonmax']),
+    ]
     for line in frame:
         line = project(line, plotdef['projstring'])
         x = line[:, 0]

--- a/docs/plot/plot.py
+++ b/docs/plot/plot.py
@@ -62,7 +62,7 @@ from shapely.ops import transform
 from descartes import PolygonPatch
 
 PROJ = '../../src/proj'
-#PROJ = 'proj'
+PROJ_LIB = '../../nad'
 
 LINE_LOW = 'data/coastline.geojson'
 LINE_MED = 'data/coastline50.geojson'
@@ -154,7 +154,8 @@ def project(coordinates, proj_string, in_radians=False):
     args = [PROJ, '-b']
     args.extend(proj_string.split(' '))
 
-    proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                            env={'PROJ_LIB': os.path.abspath(PROJ_LIB)})
     stdout, _ = proc.communicate(coordinates.tobytes())
 
     out = np.frombuffer(stdout, dtype=np.double)

--- a/docs/plot/plot.py
+++ b/docs/plot/plot.py
@@ -77,6 +77,7 @@ COLOR_LAND = '#000000'
 COLOR_COAST = '#000000'
 COLOR_GRAT = '#888888'
 
+
 def interp_coords(coords, tol):
     '''
     Interpolates extra coordinates when the euclidean distance between adjacent
@@ -128,6 +129,7 @@ def interp_coords(coords, tol):
 
     return xy
 
+
 def project(coordinates, proj_string, in_radians=False):
     '''
     Project geographical coordinates
@@ -158,12 +160,14 @@ def project(coordinates, proj_string, in_radians=False):
     out = np.frombuffer(stdout, dtype=np.double)
     return np.reshape(out, (-1, 2))
 
+
 def project_xy(x, y, proj_string):
     '''
     Wrapper for project() that works with shapely.ops.transform().
     '''
     a = project(zip(x, y), proj_string)
     return zip(*a)
+
 
 def meridian(lon, lat_min, lat_max):
     '''
@@ -174,6 +178,7 @@ def meridian(lon, lat_min, lat_max):
     coords[:, 1] = np.linspace(lat_min, lat_max, N_POINTS)
     return coords
 
+
 def parallel(lat, lon_min, lon_max):
     '''
     Calculate parallel coordinates.
@@ -182,6 +187,7 @@ def parallel(lat, lon_min, lon_max):
     coords[:, 0] = np.linspace(lon_min, lon_max, N_POINTS)
     coords[:, 1] = lat
     return coords
+
 
 def build_graticule(lonmin=-180, lonmax=180, latmin=-85, latmax=85):
     '''
@@ -214,6 +220,7 @@ def resample_polygon(polygon):
     for int_ring in polygon.interiors:
         rings.append(interp_coords(int_ring.coords.xy, 2))
     return Polygon(ext, rings)
+
 
 def plotproj(plotdef, data, outdir):
     '''
@@ -342,6 +349,7 @@ def main():
 
     for key in data:
         data[key].close()
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/docs/plot/plot.py
+++ b/docs/plot/plot.py
@@ -118,9 +118,9 @@ def interp_coords(coords, tol):
         xy.append((x[offset:i], y[offset:i]))
 
         # Interpolate between points above tolerance.
-        n = round(dsts[i] / tol/2)
-        x1 = np.linspace(x[i], x[i + 1], n + 2)
-        y1 = np.linspace(y[i], y[i + 1], n + 2)
+        n = np.ceil(dsts[i] / tol)
+        x1 = np.linspace(x[i], x[i + 1], n + 1)
+        y1 = np.linspace(y[i], y[i + 1], n + 1)
         xy.append((x1[:-1], y1[:-1]))
 
         offset = i + 1


### PR DESCRIPTION
Optimizing the interpolation is about 8-10% faster, though of course, most of the time is spent starting and stopping `proj` processes, so it's maybe about 30 s faster out of 6 minutes.

Also, the interpolation did not quite work correctly originally; it did not insure that point distances were actually below the tolerance, so there are a few small differences in the results.

I did not re-create the images, as I assume you'll be redoing stuff when things in OSGeo/proj.4#525 are decided.